### PR TITLE
Ensure lat/lon attrs in the `xr.Dataset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ ds = uscrn.to_xarray(df)  # xarray.Dataset, with soil depth dimension if applica
 
 Both `df` (pandas) and `ds` (xarray) include dataset and variable metadata.
 For `df`, these are in `df.attrs` and can be preserved by
-writing to Parquet with the PyArrow engine with pandas v2.1+.
+writing to Parquet with the PyArrow engine[^d] with
+[pandas v2.1+](https://pandas.pydata.org/docs/whatsnew/v2.1.0.html#other-enhancements).
 
 ```python
 df.to_parquet("uscrn_2019_hourly.parquet", engine="pyarrow")
@@ -40,3 +41,4 @@ pip install --no-deps uscrn
 [^a]: Use `uscrn.load_meta()` to load the site metadata table.
 [^b]: Not counting the `import` statement...
 [^c]: `uscrn` is not yet on conda-forge.
+[^d]: Or the fastparquet engine with [fastparquet v2024.2.0+](https://github.com/dask/fastparquet/commit/9d7ee90e38103fef3dd1bd2f5eb0654b8bd3fdff).

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -91,6 +91,9 @@ def test_read(which, url):
 
     ds = to_xarray(df)
 
+    assert {"long_name", "units"} <= ds.latitude.attrs.keys()
+    assert {"long_name", "units"} <= ds.longitude.attrs.keys()
+
     if which == "subhourly":
         assert "depth" not in ds.dims
     elif which == "hourly":

--- a/uscrn/data.py
+++ b/uscrn/data.py
@@ -588,7 +588,7 @@ def to_xarray(
                 i = inds[0]
                 return x[i]
 
-        return xr.apply_ufunc(func, da, input_core_dims=[["time"]], vectorize=True)
+        return xr.apply_ufunc(func, da, input_core_dims=[["time"]], vectorize=True, keep_attrs=True)
 
     lat0 = first(ds["latitude"])
     lon0 = first(ds["longitude"])


### PR DESCRIPTION
They were lost in the apply-ufunc application.

Also, since 2024.2.0 version (released on PyPI yesterday), fastparquet [supports](https://github.com/dask/fastparquet/commit/9d7ee90e38103fef3dd1bd2f5eb0654b8bd3fdff) the `.attrs` roundtrip.

* [x] update doc mentions of attr preservation, including links