### PR TITLE
Apply QC flags

### DIFF
--- a/docs/examples/nrt.ipynb
+++ b/docs/examples/nrt.ipynb
@@ -183,7 +183,7 @@
     "## Specific period of hourly data\n",
     "\n",
     "Date selection works by file, not by the data inside the file.\n",
-    "In general, the data is an hour behind the file date/time.\n",
+    "In general, the data are an hour behind the file date/time.\n",
     "See the notes in {func}`uscrn.get_nrt_data` for more details."
    ]
   },

--- a/docs/examples/nrt.ipynb
+++ b/docs/examples/nrt.ipynb
@@ -257,11 +257,7 @@
    },
    "outputs": [],
    "source": [
-    "df = uscrn.get_nrt_data(\n",
-    "    -1,\n",
-    "    \"daily\",\n",
-    "    n_jobs=1,\n",
-    ")"
+    "df = uscrn.get_nrt_data(-1, \"daily\")"
    ]
   },
   {
@@ -303,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/docs/examples/qc.ipynb
+++ b/docs/examples/qc.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "c46a3bbf",
    "metadata": {
     "tags": [
@@ -31,145 +31,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "id": "e2936b91",
    "metadata": {
     "tags": [
      "hide-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Discovering files...\n",
-      "1 file(s) found\n",
-      "https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/2019/CRNH0203-2019-CO_Boulder_14_W.txt\n",
-      "Reading files...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Parallel(n_jobs=1)]: Done   1 tasks      | elapsed:    0.8s\n",
-      "[Parallel(n_jobs=1)]: Done   1 tasks      | elapsed:    0.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Discovering files...\n",
-      "1 file(s) found\n",
-      "https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/2019/CRNH0203-2019-CO_Boulder_14_W.txt\n",
-      "Reading files...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Parallel(n_jobs=1)]: Done   1 tasks      | elapsed:    0.8s\n",
-      "[Parallel(n_jobs=1)]: Done   1 tasks      | elapsed:    0.8s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "station_id = \"1045\"  # Boulder, CO\n",
     "\n",
     "df = uscrn.get_data(2019, \"hourly\", station_id=station_id, n_jobs=1)\n",
-    "df_no_qc = uscrn.get_data(2019, \"hourly\", station_id=station_id, apply_qc=False, n_jobs=1)"
+    "df_no_qc = uscrn.get_data(2019, \"hourly\", station_id=station_id, apply_qc=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "id": "c47859cc",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "      <th>3</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>solarad</th>\n",
-       "      <td>8756</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>solarad_max</th>\n",
-       "      <td>8750</td>\n",
-       "      <td>10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>solarad_min</th>\n",
-       "      <td>8756</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sur_temp</th>\n",
-       "      <td>8756</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sur_temp_max</th>\n",
-       "      <td>8756</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sur_temp_min</th>\n",
-       "      <td>8756</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>rh_hr_avg</th>\n",
-       "      <td>8760</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                 0     3\n",
-       "solarad       8756     4\n",
-       "solarad_max   8750    10\n",
-       "solarad_min   8756     4\n",
-       "sur_temp      8756     4\n",
-       "sur_temp_max  8756     4\n",
-       "sur_temp_min  8756     4\n",
-       "rh_hr_avg     8760  <NA>"
-      ]
-     },
-     "execution_count": 58,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "qc_vns = [k for k, v in df.attrs[\"attrs\"].items() if v[\"qc_flag_name\"]]\n",
     "\n",
@@ -184,67 +66,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "7008a9de",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>qc</th>\n",
-       "      <th>no qc</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>solarad_max</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>False</th>\n",
-       "      <td>8749</td>\n",
-       "      <td>8759</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>True</th>\n",
-       "      <td>11</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "               qc  no qc\n",
-       "solarad_max             \n",
-       "False        8749   8759\n",
-       "True           11      1"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "vn = counts.sort_values(by=\"0\").iloc[0].name\n",
     "\n",
@@ -259,24 +84,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "c6f94421",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "sur_temp_type\n",
-       "C    8759\n",
-       "U       1\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.sur_temp_type.value_counts()"
    ]
@@ -293,82 +104,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "4504ef56",
    "metadata": {
     "tags": [
      "hide-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Discovering files...\n",
-      "  Looking for files in these years\n",
-      "  - 2025\n",
-      "Found 4 file(s) to load\n",
-      "https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/updates/2025/CRN60H0203-202504061500.txt\n",
-      "...\n",
-      "https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/updates/2025/CRN60H0203-202504061800.txt\n",
-      "Reading files...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Parallel(n_jobs=2)]: Using backend LokyBackend with 2 concurrent workers.\n",
-      "[Parallel(n_jobs=2)]: Done   1 tasks      | elapsed:    0.2s\n",
-      "[Parallel(n_jobs=2)]: Done   2 out of   4 | elapsed:    0.2s remaining:    0.2s\n",
-      "[Parallel(n_jobs=2)]: Done   4 out of   4 | elapsed:    0.6s finished\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = uscrn.get_nrt_data((-4, None), \"hourly\", n_jobs=2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "0b7151de",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "sur_temp_type\n",
-       "C    567\n",
-       "U     60\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.sur_temp_type.value_counts()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "id": "9b059dd8",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['23801', '23802', '63862', '63867', '63868', '63891', '63892', '63893', '63894', '63895', '63897', '63899', '73801', '73802', '73803']\n",
-      "15\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "wbans = sorted(df.query(\"sur_temp_type == 'U'\").wban.unique())\n",
     "print(wbans)\n",

--- a/docs/examples/qc.ipynb
+++ b/docs/examples/qc.ipynb
@@ -1,0 +1,400 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "aa45fe06",
+   "metadata": {},
+   "source": [
+    "# QC flags\n",
+    "\n",
+    "By default, the QC flags are applied. This means that for numeric data columns that have a QC flag column, values where the QC flag is not \"0\" are set to NaN.\n",
+    "\n",
+    "See {doc}`select-sites` for more information about selecting sites and\n",
+    "{doc}`daily` / {func}`uscrn.get_data` and {doc}`nrt` / {func}`uscrn.get_nrt_data` for more information about loading data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c46a3bbf",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "import uscrn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "e2936b91",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Discovering files...\n",
+      "1 file(s) found\n",
+      "https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/2019/CRNH0203-2019-CO_Boulder_14_W.txt\n",
+      "Reading files...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=1)]: Done   1 tasks      | elapsed:    0.8s\n",
+      "[Parallel(n_jobs=1)]: Done   1 tasks      | elapsed:    0.8s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Discovering files...\n",
+      "1 file(s) found\n",
+      "https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/2019/CRNH0203-2019-CO_Boulder_14_W.txt\n",
+      "Reading files...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=1)]: Done   1 tasks      | elapsed:    0.8s\n",
+      "[Parallel(n_jobs=1)]: Done   1 tasks      | elapsed:    0.8s\n"
+     ]
+    }
+   ],
+   "source": [
+    "station_id = \"1045\"  # Boulder, CO\n",
+    "\n",
+    "df = uscrn.get_data(2019, \"hourly\", station_id=station_id, n_jobs=1)\n",
+    "df_no_qc = uscrn.get_data(2019, \"hourly\", station_id=station_id, apply_qc=False, n_jobs=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "c47859cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>3</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>solarad</th>\n",
+       "      <td>8756</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>solarad_max</th>\n",
+       "      <td>8750</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>solarad_min</th>\n",
+       "      <td>8756</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sur_temp</th>\n",
+       "      <td>8756</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sur_temp_max</th>\n",
+       "      <td>8756</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sur_temp_min</th>\n",
+       "      <td>8756</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>rh_hr_avg</th>\n",
+       "      <td>8760</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 0     3\n",
+       "solarad       8756     4\n",
+       "solarad_max   8750    10\n",
+       "solarad_min   8756     4\n",
+       "sur_temp      8756     4\n",
+       "sur_temp_max  8756     4\n",
+       "sur_temp_min  8756     4\n",
+       "rh_hr_avg     8760  <NA>"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc_vns = [k for k, v in df.attrs[\"attrs\"].items() if v[\"qc_flag_name\"]]\n",
+    "\n",
+    "counts = []\n",
+    "for vn in qc_vns:\n",
+    "    fn = df.attrs[\"attrs\"][vn][\"qc_flag_name\"]\n",
+    "    counts.append(df[fn].value_counts().convert_dtypes().rename(vn))\n",
+    "\n",
+    "counts = pd.DataFrame(counts)\n",
+    "counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "7008a9de",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>qc</th>\n",
+       "      <th>no qc</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>solarad_max</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>False</th>\n",
+       "      <td>8749</td>\n",
+       "      <td>8759</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>True</th>\n",
+       "      <td>11</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               qc  no qc\n",
+       "solarad_max             \n",
+       "False        8749   8759\n",
+       "True           11      1"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vn = counts.sort_values(by=\"0\").iloc[0].name\n",
+    "\n",
+    "pd.concat(\n",
+    "    [\n",
+    "        df[vn].isnull().value_counts().rename(\"qc\"),\n",
+    "        df_no_qc[vn].isnull().value_counts().rename(\"no qc\"),\n",
+    "    ],\n",
+    "    axis=1,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "c6f94421",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "sur_temp_type\n",
+       "C    8759\n",
+       "U       1\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.sur_temp_type.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed45394c",
+   "metadata": {},
+   "source": [
+    "## IR surface measurement type\n",
+    "\n",
+    "NRT data are (presumably) more likely to have non-corrected values present."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "4504ef56",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Discovering files...\n",
+      "  Looking for files in these years\n",
+      "  - 2025\n",
+      "Found 4 file(s) to load\n",
+      "https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/updates/2025/CRN60H0203-202504061500.txt\n",
+      "...\n",
+      "https://www.ncei.noaa.gov/pub/data/uscrn/products/hourly02/updates/2025/CRN60H0203-202504061800.txt\n",
+      "Reading files...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=2)]: Using backend LokyBackend with 2 concurrent workers.\n",
+      "[Parallel(n_jobs=2)]: Done   1 tasks      | elapsed:    0.2s\n",
+      "[Parallel(n_jobs=2)]: Done   2 out of   4 | elapsed:    0.2s remaining:    0.2s\n",
+      "[Parallel(n_jobs=2)]: Done   4 out of   4 | elapsed:    0.6s finished\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = uscrn.get_nrt_data((-4, None), \"hourly\", n_jobs=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "0b7151de",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "sur_temp_type\n",
+       "C    567\n",
+       "U     60\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.sur_temp_type.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "9b059dd8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['23801', '23802', '63862', '63867', '63868', '63891', '63892', '63893', '63894', '63895', '63897', '63899', '73801', '73802', '73803']\n",
+      "15\n"
+     ]
+    }
+   ],
+   "source": [
+    "wbans = sorted(df.query(\"sur_temp_type == 'U'\").wban.unique())\n",
+    "print(wbans)\n",
+    "print(len(wbans))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ examples/daily.ipynb
 examples/nrt.ipynb
 examples/stations.ipynb
 examples/select-sites.ipynb
+examples/qc.ipynb
 ```
 
 ```{toctree}

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -95,6 +95,8 @@ def test_load_attrs():
                 "dtype",
                 "categories",
                 "xarray_only",
+                "qc_flag_name",
+                "type_flag_name",
             }
 
 

--- a/uscrn/attrs.py
+++ b/uscrn/attrs.py
@@ -155,6 +155,20 @@ def load_attrs() -> dict[str, dict[str, Any]]:
             if "categories" not in v:
                 v["categories"] = False
 
+    # flag_name defaults to None
+    pref = "QC flag for "
+    for which in WHICHS:
+        for _, v in attrs[which]["columns"].items():
+            v["flag_name"] = None
+
+        long_name_to_name = {v["long_name"]: k for k, v in attrs[which]["columns"].items()}
+        flag_names = [name for name in attrs[which]["columns"] if name.endswith("_flag")]
+        for flag_name in flag_names:
+            flag_long_name = attrs[which]["columns"][flag_name]["long_name"]
+            assert flag_long_name.startswith(pref)
+            flag_for = long_name_to_name[flag_long_name[len(pref) :]]
+            attrs[which]["columns"][flag_for]["flag_name"] = flag_name
+
     return attrs
 
 

--- a/uscrn/attrs.py
+++ b/uscrn/attrs.py
@@ -155,11 +155,12 @@ def load_attrs() -> dict[str, dict[str, Any]]:
             if "categories" not in v:
                 v["categories"] = False
 
-    # flag_name defaults to None
+    # QC flag name defaults to None
+    # (only for selected variables in subhourly and hourly data)
     pref = "QC flag for "
     for which in WHICHS:
         for _, v in attrs[which]["columns"].items():
-            v["flag_name"] = None
+            v["qc_flag_name"] = None
 
         long_name_to_name = {v["long_name"]: k for k, v in attrs[which]["columns"].items()}
         flag_names = [name for name in attrs[which]["columns"] if name.endswith("_flag")]
@@ -167,7 +168,32 @@ def load_attrs() -> dict[str, dict[str, Any]]:
             flag_long_name = attrs[which]["columns"][flag_name]["long_name"]
             assert flag_long_name.startswith(pref)
             flag_for = long_name_to_name[flag_long_name[len(pref) :]]
-            attrs[which]["columns"][flag_for]["flag_name"] = flag_name
+            attrs[which]["columns"][flag_for]["qc_flag_name"] = flag_name
+
+    # type flag name defaults to None
+    # (only for infrared surface temperature)
+    for which in WHICHS:
+        for _, v in attrs[which]["columns"].items():
+            v["type_flag_name"] = None
+
+        if which == "subhourly":
+            flag_names = ["st_type"]
+            flag_fors = ["surface_temperature"]
+        else:
+            pref = "sur_temp"
+            flag_fors = [
+                name
+                for name in attrs[which]["columns"]
+                if name.startswith(pref) and not name.endswith(("_flag", "_type"))
+            ]
+            assert len(flag_fors) == 3
+            flag_name = pref + ("" if which == "hourly" else f"_{which}") + "_type"
+            flag_names = [flag_name] * len(flag_fors)
+
+        for flag_name, flag_for in zip(flag_names, flag_fors):
+            assert flag_name in attrs[which]["columns"]
+            assert flag_for in attrs[which]["columns"]
+            attrs[which]["columns"][flag_for]["type_flag_name"] = flag_name
 
     return attrs
 

--- a/uscrn/attrs.yml
+++ b/uscrn/attrs.yml
@@ -160,7 +160,7 @@ subhourly:
       units: m s-1
       description: Average wind speed, in meters per second, at a height of 1.5 meters.
     - name: wind_flag
-      long_name: QC flag for 5-min average wind speed
+      long_name: QC flag for 5-min average wind speed at 1.5 m
       units: null
       description: >-
         QC flag for the wind speed measurement.

--- a/uscrn/data.py
+++ b/uscrn/data.py
@@ -565,9 +565,10 @@ def get_data(
 
     df = pd.concat(dfs, axis="index", ignore_index=True, copy=False)
 
+    # Apply QC flags?
     if apply_qc:
         for col in df.columns:
-            flag_col = stored_attrs[which]["columns"][col]["flag_name"]
+            flag_col = stored_attrs[which]["columns"][col]["qc_flag_name"]
             if flag_col is None:
                 continue
             good = df[flag_col] == "0"

--- a/uscrn/data.py
+++ b/uscrn/data.py
@@ -440,7 +440,7 @@ def get_data(
         Drop rows where all data cols are missing data.
     apply_qc
         Apply the QC flags, masking non-"good" data with NaN.
-        Only impacts subhourly and hourly data.
+        This only impacts subhourly and hourly data, and only certain variables.
 
     See Also
     --------

--- a/uscrn/data.py
+++ b/uscrn/data.py
@@ -398,10 +398,10 @@ def get_data(
     which: Literal["subhourly", "hourly", "daily", "monthly"] = "daily",
     *,
     station_id: str | Iterable[str] | None = None,
-    n_jobs: int | None = -2,
     cat: bool = False,
     dropna: bool = False,
     apply_qc: bool = True,
+    n_jobs: int | None = -2,
 ) -> pd.DataFrame:
     """Get USCRN archive data.
 
@@ -431,9 +431,6 @@ def get_data(
     station_id
         Site or sites (specified using USCRN station ID) to get data for.
         Default is to get all sites.
-    n_jobs
-        Number of parallel joblib jobs to use for loading the individual files.
-        The default is ``-2``, which means to use one less than joblib's detected max.
     cat
         Convert some columns to pandas categorical type.
     dropna
@@ -441,6 +438,9 @@ def get_data(
     apply_qc
         Apply the QC flags, masking non-"good" data with NaN.
         This only impacts subhourly and hourly data, and only certain variables.
+    n_jobs
+        Number of parallel joblib jobs to use for loading the individual files.
+        The default is ``-2``, which means to use one less than joblib's detected max.
 
     See Also
     --------
@@ -623,8 +623,8 @@ def get_nrt_data(
     period: Any | tuple[Any, Any],
     which: Literal["hourly", "daily"] = "hourly",
     *,
-    n_jobs: int | None = None,
     cat: bool = False,
+    n_jobs: int | None = None,
 ) -> pd.DataFrame:
     """Get USCRN near-real-time data.
 
@@ -664,11 +664,11 @@ def get_nrt_data(
     which
         Which dataset.
         Only hourly and daily are available.
+    cat
+        Convert some columns to pandas categorical type.
     n_jobs
         Number of parallel joblib jobs to use for loading the individual files.
         The default is to use ``min(joblib.cpu_count() - 1, num_files)``.
-    cat
-        Convert some columns to pandas categorical type.
 
     Examples
     --------


### PR DESCRIPTION
by default, though you can disable it with `apply_qc=False`. Also make the n-jobs calculation a bit smarter and use it for get-data too, since with site selection the number of files can be smaller than n-cpus.

Closes #11 