### PR TITLE
Address mypy complaints about attrs dict updates with kwarg syntax

### DIFF
--- a/uscrn/data.py
+++ b/uscrn/data.py
@@ -53,7 +53,7 @@ def load_meta(*, cat: bool = False) -> pd.DataFrame:
         for col in ["status", "operation", "network"]:
             df[col] = df[col].astype("category")
 
-    df.attrs.update(created=now)
+    df.attrs["created"] = now
 
     return df
 
@@ -178,7 +178,7 @@ def read_subhourly(fp, *, cat: bool = False) -> pd.DataFrame:
         for col, cats in col_info.categorical.items():
             df[col] = df[col].astype(pd.CategoricalDtype(categories=cats, ordered=False))
 
-    df.attrs.update(which="subhourly")
+    df.attrs["which"] = "subhourly"
 
     return df
 
@@ -228,7 +228,7 @@ def read_hourly(fp, *, cat: bool = False, **kwargs) -> pd.DataFrame:
         for col, cats in col_info.categorical.items():
             df[col] = df[col].astype(pd.CategoricalDtype(categories=cats, ordered=False))
 
-    df.attrs.update(which="hourly")
+    df.attrs["which"] = "hourly"
 
     return df
 
@@ -292,7 +292,7 @@ def read_daily(fp, *, cat: bool = False, **kwargs) -> pd.DataFrame:
         for col, cats in col_info.categorical.items():
             df[col] = df[col].astype(pd.CategoricalDtype(categories=cats, ordered=False))
 
-    df.attrs.update(which="daily")
+    df.attrs["which"] = "daily"
 
     return df
 
@@ -353,7 +353,7 @@ def read_monthly(fp, *, cat: bool = False) -> pd.DataFrame:
         for col, cats in col_info.categorical.items():
             df[col] = df[col].astype(pd.CategoricalDtype(categories=cats, ordered=False))
 
-    df.attrs.update(which="monthly")
+    df.attrs["which"] = "monthly"
 
     return df
 


### PR DESCRIPTION
Recently mypy started complaining about some of these, possibly due to a change in typeshed (type annotations for builtins like dict). mypy v1.17.1 when I first noticed

```
uscrn/data.py:56: error: No overload variant of "update" of "MutableMapping" matches argument type "datetime"  [call-overload]
uscrn/data.py:56: note: Possible overload variants:
uscrn/data.py:56: note:     def update(self, SupportsKeysAndGetItem[Optional[Hashable], Any], /) -> None
uscrn/data.py:56: note:     def update(self, Iterable[tuple[Optional[Hashable], Any]], /) -> None
uscrn/data.py:181: error: No overload variant of "update" of "MutableMapping" matches argument type "str"  [call-overload]
uscrn/data.py:181: note: Possible overload variants:
uscrn/data.py:181: note:     def update(self, SupportsKeysAndGetItem[Optional[Hashable], Any], /) -> None
uscrn/data.py:181: note:     def update(self, Iterable[tuple[Optional[Hashable], Any]], /) -> None
uscrn/data.py:356: error: No overload variant of "update" of "MutableMapping" matches argument type "str"  [call-overload]
uscrn/data.py:356: note: Possible overload variants:
uscrn/data.py:356: note:     def update(self, SupportsKeysAndGetItem[Optional[Hashable], Any], /) -> None
uscrn/data.py:356: note:     def update(self, Iterable[tuple[Optional[Hashable], Any]], /) -> None
```

not really any reason to use `.update` in these cases anyway

mypy seems to be fine with the multiple-kw dict update cases